### PR TITLE
feat(ui-store): set ui store and refactor requests to hooks

### DIFF
--- a/src/components/HeadlinersContainer.tsx
+++ b/src/components/HeadlinersContainer.tsx
@@ -2,9 +2,14 @@ import React from 'react'
 import HeadlinersRenderer from './HeadlinersRenderer'
 import { useSelector } from 'react-redux'
 import { RootStore } from '../store/types'
+import { loadingStateRange } from '../store/actions/ui/types'
+import HeadlinersPlaceholder from './HeadlinersPlaceholder'
+import { LOADING_STATUSES } from '../store/actions/consts'
 
 const HeadlinersContainer: React.FC = () => {
   const totalResults: number = useSelector((state: RootStore) => state.headliners.totalResults)
+  const loadingState: loadingStateRange = useSelector((state: RootStore) => state.ui.loadingHeadliners)
+
   return (
     <div className='headliners-container'>
       <div className='headliners-container__header'>
@@ -15,7 +20,9 @@ const HeadlinersContainer: React.FC = () => {
           {totalResults} headliners
         </div>
       </div>
-      <HeadlinersRenderer />
+      { loadingState === LOADING_STATUSES.loading && <HeadlinersPlaceholder quantity={3}/> }
+      { loadingState === LOADING_STATUSES.success && <HeadlinersRenderer /> }
+      { loadingState === LOADING_STATUSES.error && <div>Sorry, our server got sick and went home early </div> }
     </div>
   )
 }

--- a/src/components/HeadlinersRenderer.tsx
+++ b/src/components/HeadlinersRenderer.tsx
@@ -1,25 +1,21 @@
 import React from 'react'
-import { ENTRY_headliners } from '../store/actions/headliners/types'
+import { ENTRY_headliner } from '../store/actions/headliners/types'
 import { useSelector } from 'react-redux'
-import HeadlinersPlaceholder from './HeadlinersPlaceholder'
 import HeadlinerTile from './HeadlinerTile'
+import { RootStore } from '../store/types'
 
 const HeadlinersRenderer: React.FC = () => {
-  const { headliners }: ENTRY_headliners = useSelector(({ headliners }) => headliners)
+  const headliners: ENTRY_headliner[] | null = useSelector(({ headliners }: RootStore) => headliners.headliners)
 
   return (
-    <>
-      {!headliners && <HeadlinersPlaceholder quantity={3} />}
-      {!!headliners && <div className='headliners-renderer'>
-        {headliners.map((headliner) => (
-          <HeadlinerTile
-            key={headliner.title}
-            {...headliner}
-          />
-        ))}
-      </div>
-      }
-    </>
+    <div className='headliners-renderer'>
+      {headliners.map((headliner) => (
+        <HeadlinerTile
+          key={headliner.title}
+          {...headliner}
+        />
+      ))}
+    </div>
   )
 }
 

--- a/src/components/SearchButton.tsx
+++ b/src/components/SearchButton.tsx
@@ -1,61 +1,28 @@
 import React, { useEffect, useState } from 'react'
-import { ENTRY_Source } from '../store/actions/sources/types'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { RootStore } from '../store/types'
-import { RequestStatusRange } from '../utils/api/types'
-import { requestHeadlines } from '../utils/api/api'
-import { getHeadliners } from '../store/actions/headliners/actions'
-import { formatHeadersResponseData } from '../utils/api/apiMethods'
-
-const formatDataForRequest = (sources: ENTRY_Source[]): string => {
-  return sources.map(({ value }) => value).join(',')
-}
+import useHeadlinersRequest from '../hooks/useHeadlinersRequest'
+import { ENTRY_Source } from '../store/actions/sources/types'
+import { LOADING_STATUSES } from '../store/actions/consts'
 
 const SearchButton: React.FC = () => {
-  const dispatch = useDispatch()
-  const sources: ENTRY_Source[] = useSelector((state: RootStore) => state.sources.sources)
-  const chosenSources: ENTRY_Source[] = useSelector((state: RootStore) => state.sources.chosenSources)
-
-  const [ requestState, setRequestState ] = useState<RequestStatusRange>(null)
+  const { status, triggerRequest } = useHeadlinersRequest()
+  const sources: ENTRY_Source[] = useSelector(({ sources}: RootStore) => sources.sources)
+  const chosenSources: ENTRY_Source[] = useSelector(({ sources }: RootStore) => sources.chosenSources)
   const [ disabledStatus, setDisabilityStatus ] = useState<boolean>(true)
-
-  const hasSources = !!sources.length || !!chosenSources.length
-
-  const requestHeadlinersList = async () => {
-    setRequestState('loading')
-    setDisabilityStatus(true)
-
-    try {
-      const sourcesToFormat = !!chosenSources.length ? chosenSources : sources
-
-      const formattedSources = formatDataForRequest(sourcesToFormat)
-      const { data } = await requestHeadlines({ sources: formattedSources, pageSize: 20 })
-      const formattedData = formatHeadersResponseData(data)
-
-      dispatch(getHeadliners(formattedData))
-      setRequestState('success')
-
-    } catch (e) {
-      setRequestState('error')
-    }
-  }
-
-  const requestTrigger = (): void => {
-    if (hasSources) {
-      requestHeadlinersList()
-    }
-  }
 
   useEffect(() => {
     disabledStatus && setDisabilityStatus(false)
   }, [ sources, chosenSources ])
 
+  const hasNoSources = sources.length === 0
+
   return (
     <div className='search-button'>
       <button
         className='button'
-        onClick={requestTrigger}
-        disabled={disabledStatus}
+        onClick={() => triggerRequest('add')}
+        disabled={hasNoSources || disabledStatus || status === LOADING_STATUSES.loading}
       >
         Confirm selection
       </button>

--- a/src/hooks/useHeadlinersRequest.tsx
+++ b/src/hooks/useHeadlinersRequest.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { RootStore } from '../store/types'
+import { setUIState } from '../store/actions/ui/actions'
+import { LOADING_STATUSES } from '../store/actions/consts'
+import { ENTRY_Source } from '../store/actions/sources/types'
+import { requestHeadlines } from '../utils/api/api'
+import { formatHeadersResponseData } from '../utils/api/apiMethods'
+import { getHeadliners, appendHeadliners } from '../store/actions/headliners/actions'
+import { loadingStateRange } from '../store/actions/ui/types'
+
+type OperationTypeRange = 'add' | 'append'
+
+interface OperationTypeObjectInterface {
+  add: 'add',
+  append: 'append'
+}
+
+export const OperationType: OperationTypeObjectInterface = {
+  add: 'add',
+  append: 'append'
+}
+
+type TriggerRequest = (operationType: OperationTypeRange) => void
+
+interface HeadlinersHookInterface {
+  status: loadingStateRange,
+  triggerRequest: TriggerRequest
+}
+
+const formatDataForRequest = (sources: ENTRY_Source[]): string => {
+  return sources.map(({ value }) => value).join(',')
+}
+
+const useHeadlinersRequest = (): HeadlinersHookInterface => {
+  const pageCount: number = useSelector(({ ui }: RootStore) => ui.pageCount)
+  const loadingHeadliners: loadingStateRange = useSelector(({ ui }: RootStore) => ui.loadingHeadliners)
+  const sources: ENTRY_Source[] = useSelector(({ sources }: RootStore) => sources.sources)
+  const chosenSources: ENTRY_Source[] = useSelector(({ sources }: RootStore) => sources.chosenSources)
+  const dispatch = useDispatch()
+
+  const triggerRequest = async (operationType: OperationTypeRange) => {
+    dispatch(setUIState({ loadingHeadliners: LOADING_STATUSES.loading }))
+
+    try {
+      const sourcesToFormat = !!chosenSources.length ? chosenSources : sources
+      const formattedSources = formatDataForRequest(sourcesToFormat)
+      let newPageCount: number = pageCount
+      let requestData: any = null
+      let action: (data: object) => void | null = null
+
+      switch (operationType) {
+        case OperationType.add:
+
+          const addResponseData = await requestHeadlines({ sources: formattedSources })
+          newPageCount = 1
+          requestData = addResponseData.data
+          action = getHeadliners
+          break
+
+        case OperationType.append:
+
+          newPageCount++
+          const appendResponseData = await requestHeadlines({ sources: formattedSources, page: newPageCount })
+          requestData = appendResponseData.data
+          action = appendHeadliners
+          break
+      }
+
+      const formattedData = formatHeadersResponseData(requestData)
+      dispatch(action(formattedData))
+      dispatch(setUIState({ loadingHeadliners: LOADING_STATUSES.success, pageCount: newPageCount }))
+
+    } catch (e) {
+      dispatch(setUIState({ loadingHeadliners: LOADING_STATUSES.error, pageCount: 0 }))
+    }
+  }
+
+  return {
+    status: loadingHeadliners,
+    triggerRequest
+  }
+}
+
+export default useHeadlinersRequest

--- a/src/hooks/useSourcesRequest.tsx
+++ b/src/hooks/useSourcesRequest.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { loadingStateRange } from '../store/actions/ui/types'
+import { useDispatch, useSelector } from 'react-redux'
+import { SourcesParams } from '../utils/api/types'
+import { RootStore } from '../store/types'
+import { requestSources } from '../utils/api/api'
+import { formatSourcesResponseData } from '../utils/api/apiMethods'
+import { setSources } from '../store/actions/sources/actions'
+import { setUIState } from '../store/actions/ui/actions'
+import { LOADING_STATUSES } from '../store/actions/consts'
+
+type TriggerRequest = () => void
+
+interface SourcesHookInterface {
+  status: loadingStateRange,
+  triggerRequest: TriggerRequest
+}
+
+const useSourcesRequest = (): SourcesHookInterface => {
+  const dispatch = useDispatch()
+
+  const searchParams: SourcesParams = useSelector((state: RootStore) => state.searchParams)
+  const loadingSources: loadingStateRange = useSelector(({ ui }: RootStore) => ui.loadingSources)
+
+  const triggerRequest = async () => {
+    dispatch(setUIState({ loadingSources: LOADING_STATUSES.loading }))
+
+    try {
+      const { data }: any = await requestSources(searchParams)
+      const { sources } = formatSourcesResponseData(data)
+
+      dispatch(setSources({ sources }))
+      dispatch(setUIState({ loadingSources: LOADING_STATUSES.success }))
+
+    } catch (e) {
+      dispatch(setUIState({ loadingSources: LOADING_STATUSES.error }))
+    }
+  }
+
+  return {
+    status: loadingSources,
+    triggerRequest
+  }
+}
+
+export default useSourcesRequest

--- a/src/store/actions/consts.ts
+++ b/src/store/actions/consts.ts
@@ -1,4 +1,5 @@
 import { ENTRY_headlinerStatus } from './headliners/types'
+import { loadingStateObject } from './ui/types'
 
 // headliners list action names
 export const GET_HEADLINERS: string = 'GET_HEADLINERS'
@@ -23,3 +24,13 @@ export const SET_CHOSEN_SOURCES: string = 'SET_CHOSEN_SOURCES'
 
 // searchParams action names
 export const SET_PARAMETERS: string = 'SET_PARAMETERS'
+
+// ui action names
+export const SET_LOADING_STATE: string = 'SET_LOADING_STATE'
+
+export const LOADING_STATUSES: loadingStateObject = {
+  loading: 'loading',
+  success: 'success',
+  error: 'error',
+  initial: null
+}

--- a/src/store/actions/ui/actions.ts
+++ b/src/store/actions/ui/actions.ts
@@ -1,0 +1,7 @@
+import { ENTRY_UIState, OUTPUT_UIState } from './types'
+import { SET_LOADING_STATE } from '../consts'
+
+export const setUIState = (payload: ENTRY_UIState): OUTPUT_UIState => ({
+  type: SET_LOADING_STATE,
+  payload
+})

--- a/src/store/actions/ui/types.ts
+++ b/src/store/actions/ui/types.ts
@@ -1,0 +1,20 @@
+export type loadingStateRange = 'loading' | 'success' | 'error' | null
+
+export interface loadingStateObject {
+  loading: 'loading',
+  success: 'success',
+  error: 'error',
+  initial: null
+}
+
+// entries
+export interface ENTRY_UIState {
+  loadingHeadliners?: loadingStateRange,
+  pageCount?: number,
+  loadingSources?: loadingStateRange
+}
+
+export interface OUTPUT_UIState {
+  type: string,
+  payload: ENTRY_UIState
+}

--- a/src/store/reducers/index.tsx
+++ b/src/store/reducers/index.tsx
@@ -3,11 +3,13 @@ import headliners from './headliners'
 import toReads from './toReads'
 import sources from './sources'
 import searchParams from './searchParams'
+import ui from './ui'
 import { RootStore } from '../types'
 
 export default combineReducers<RootStore>({
   headliners,
   toReads,
   sources,
-  searchParams
+  searchParams,
+  ui
 })

--- a/src/store/reducers/types.tsx
+++ b/src/store/reducers/types.tsx
@@ -1,6 +1,7 @@
 import { ENTRY_headliner } from '../actions/headliners/types'
 import { SourcesParams } from '../../utils/api/types'
 import { ENTRY_Source } from '../actions/sources/types'
+import { loadingStateRange } from '../actions/ui/types'
 
 export interface ENTRY_headlinersStore {
   totalResults: number
@@ -20,3 +21,9 @@ export interface ENTRY_sourcesStore {
 }
 
 export interface ENTRY_searchParamsStore extends SourcesParams {}
+
+export interface ENTRY_UIStore {
+  loadingHeadliners: loadingStateRange
+  loadingSources: loadingStateRange,
+  pageCount: number
+}

--- a/src/store/reducers/ui/index.ts
+++ b/src/store/reducers/ui/index.ts
@@ -1,0 +1,23 @@
+import { ENTRY_UIStore } from '../types'
+import { OUTPUT_UIState } from '../../actions/ui/types'
+import { LOADING_STATUSES, SET_LOADING_STATE } from '../../actions/consts'
+
+const INITIAL_STATE: ENTRY_UIStore = {
+  loadingHeadliners: LOADING_STATUSES.initial,
+  loadingSources: LOADING_STATUSES.initial,
+  pageCount: 1,
+}
+
+const ui = (
+  state: ENTRY_UIStore = INITIAL_STATE,
+  { type, payload }: OUTPUT_UIState
+): ENTRY_UIStore => {
+  switch (type) {
+    case SET_LOADING_STATE:
+      return Object.assign(state, payload)
+  }
+
+  return state
+}
+
+export default ui

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -2,12 +2,14 @@ import {
   ENTRY_toReadsStore,
   ENTRY_headlinersStore,
   ENTRY_sourcesStore,
-  ENTRY_searchParamsStore
+  ENTRY_searchParamsStore,
+  ENTRY_UIStore
 } from './reducers/types'
 
 export interface RootStore {
   headliners: ENTRY_headlinersStore,
   toReads: ENTRY_toReadsStore,
   sources: ENTRY_sourcesStore,
-  searchParams: ENTRY_searchParamsStore
+  searchParams: ENTRY_searchParamsStore,
+  ui: ENTRY_UIStore
 }

--- a/src/styles/components/headliner.sass
+++ b/src/styles/components/headliner.sass
@@ -66,7 +66,7 @@
     font-weight: 300
     padding-left: 1px
     letter-spacing: .6px
-    line-height: 17px
+    line-height: 18px
     color: $color-grey-40
     margin-bottom: 13px
 

--- a/src/utils/api/types.ts
+++ b/src/utils/api/types.ts
@@ -83,7 +83,7 @@ export interface SourcesParams {
 
 export interface HeadlinersParams {
   sources: string,
-  pageSize: number
+  page?: number
 }
 
 export interface RequestBuilder {


### PR DESCRIPTION
What was done:
- create redux store for ui (loading state for sources and headliners) state in order to manage it easier
- refactor components to accommodate for global ui state
- rewrite api requests into custom Hooks to extract the logic out of specific components
