### PR TITLE
feat(headliners): implement tablet level styling and small logic changes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.fontSize": 15,
+    "editor.fontWeight": "400"
+}

--- a/src/components/HeadlinerTile.tsx
+++ b/src/components/HeadlinerTile.tsx
@@ -2,8 +2,7 @@ import React from 'react'
 import { ENTRY_headliner } from '../store/actions/headliners/types'
 import moment from 'moment'
 
-interface HeadlinerTile extends ENTRY_headliner {
-}
+interface HeadlinerTile extends ENTRY_headliner {}
 
 const HeadlinerTile: React.FC<HeadlinerTile> = ({
   urlToImage,
@@ -16,26 +15,30 @@ const HeadlinerTile: React.FC<HeadlinerTile> = ({
 }) => {
   return (
     <div className='headliner'>
-      {!!urlToImage ?
-        <img
-          className='headliner__img'
-          src={urlToImage}
-          alt={title}
-        />
-        :
-        <div className='headliner__img-placeholder'/>
-      }
+      <div className='headliner__img-wrapper'>
+        {!!urlToImage ?
+          <img
+            className='headliner__img'
+            src={urlToImage}
+            alt={title}
+          />
+          :
+          <div className='headliner__img-placeholder'/>
+        }
+      </div>
       <div className='headliner__content-wrapper'>
-        <div className='headliner__title'>
-          {title}
+        <div>
+          <div className='headliner__title'>
+            {title}
+          </div>
+          <div className='headliner__source'>
+            {source}
+          </div>
+          <div
+            className='headliner__description'
+            dangerouslySetInnerHTML={{ __html: description }}
+          />
         </div>
-        <div className='headliner__source'>
-          {source}
-        </div>
-        <div
-          className='headliner__description'
-          dangerouslySetInnerHTML={{ __html: description }}
-        />
         <div className='headliner__bottom'>
           {publishedAt &&
           <div className='headliner__date'>

--- a/src/components/SearchSources.tsx
+++ b/src/components/SearchSources.tsx
@@ -41,6 +41,8 @@ const SearchSources: React.FC = () => {
         onChange={valueChangeHandler}
         isDisabled={isDisabled}
         placeholder='Your sources'
+        className='sources-select'
+        classNamePrefix='sources-select'
       />
     </div>
   )

--- a/src/hooks/useHeadlinersRequest.tsx
+++ b/src/hooks/useHeadlinersRequest.tsx
@@ -6,7 +6,7 @@ import { LOADING_STATUSES } from '../store/actions/consts'
 import { ENTRY_Source } from '../store/actions/sources/types'
 import { requestHeadlines } from '../utils/api/api'
 import { formatHeadersResponseData } from '../utils/api/apiMethods'
-import { getHeadliners, appendHeadliners } from '../store/actions/headliners/actions'
+import { getHeadliners, appendHeadliners, overrideHeadliners } from '../store/actions/headliners/actions'
 import { loadingStateRange } from '../store/actions/ui/types'
 
 type OperationTypeRange = 'add' | 'append'
@@ -51,6 +51,7 @@ const useHeadlinersRequest = (): HeadlinersHookInterface => {
 
       switch (operationType) {
         case OperationType.add:
+          dispatch(overrideHeadliners())
 
           const addResponseData = await requestHeadlines({ sources: formattedSources })
           newPageCount = 1

--- a/src/store/actions/headliners/actions.ts
+++ b/src/store/actions/headliners/actions.ts
@@ -18,7 +18,6 @@ export const appendHeadliners = (payload: ENTRY_headliners): OUTPUT_headliners =
   payload
 })
 
-export const overrideHeadliners = (payload: ENTRY_headliners): OUTPUT_headliners => ({
-  type: REFRESH_HEADLINERS,
-  payload
+export const overrideHeadliners = (): { type: string } => ({
+  type: REFRESH_HEADLINERS
 })

--- a/src/store/reducers/headliners/index.ts
+++ b/src/store/reducers/headliners/index.ts
@@ -24,7 +24,7 @@ const headliners = (
       return appendHeadliners(state, payload)
 
     case REFRESH_HEADLINERS:
-      return payload
+      return INITIAL_STATE
   }
 
   return state

--- a/src/styles/components/buttons.sass
+++ b/src/styles/components/buttons.sass
@@ -29,3 +29,7 @@
     background-color: $color-base-blue-80
     border-color: $color-base-blue-80
     cursor: default
+
+  +media-breakpoint-up(md)
+    font-size: 19px
+    height: 42px

--- a/src/styles/components/headliner.sass
+++ b/src/styles/components/headliner.sass
@@ -4,6 +4,15 @@
   box-shadow: 0 0 0.3rem 0 rgba(0, 0, 0, .26)
   border-radius: 7px
 
+  +media-breakpoint-up(md)
+    display: flex
+    flex-direction: row-reverse
+    border: 1px solid $color-grey-75
+
+  &__img-wrapper
+    background-color: $color-grey-75
+    border-radius: 0 5px 5px 0
+
   &__img
     display: flex
     width: 100%
@@ -11,6 +20,12 @@
     object-fit: cover
     border-radius: 7px 7px 0 0
     background-color: $color-grey-75
+    flex-shrink: 0
+
+    +media-breakpoint-up(md)
+      width: 250px
+      height: 250px
+      border-radius: 0 7px 7px 0
 
   &__img-placeholder
     width: 100%
@@ -21,6 +36,7 @@
     border-radius: 7px 7px 0 0
     background-color: $color-grey-75
     position: relative
+    flex-shrink: 0
 
     &:after
       position: absolute
@@ -40,13 +56,28 @@
       background-color: $color-grey-50
       transform: rotate(45deg)
 
+    +media-breakpoint-up(md)
+      width: 250px
+      height: 250px
+      border-radius: 0 7px 7px 0
 
   &__content-wrapper
+    width: 100%
     padding: 13px 13px 15px
     margin-bottom: 10px
     border: 1px solid $color-grey-75
     border-top: none
     border-radius: 0 0 7px 7px
+
+    +media-breakpoint-up(md)
+      display: flex
+      flex-direction: column
+      justify-content: space-between
+      margin-bottom: unset
+      border: unset
+      border-right: none
+      border-radius: 7px 0 0 7px
+      padding: 15px
 
   &__title
     font-size: 24px
@@ -55,25 +86,40 @@
     color: $color-grey-15
     line-height: 27px
 
+    +media-breakpoint-up(md)
+      font-size: 30px
+      line-height: 32px
+      margin-bottom: 8px
+
   &__source
     font-size: 14px
     color: $color-grey-25
     padding-left: 1px
     margin-bottom: 13px
 
+    +media-breakpoint-up(md)
+      font-size: 18px
+
   &__description
     font-size: 15px
     font-weight: 300
     padding-left: 1px
-    letter-spacing: .6px
+    letter-spacing: .4px
     line-height: 18px
     color: $color-grey-40
     margin-bottom: 13px
+
+    +media-breakpoint-up(md)
+      font-size: 19px
+      line-height: 22px
 
   &__bottom
     display: flex
     font-size: 13px
     letter-spacing: .5px
+
+    +media-breakpoint-up(md)
+      font-size: 16px
 
   &__date
     font-weight: 300
@@ -89,6 +135,10 @@
       background-color: $color-grey-60
       right: -8px
       top: -1px
+
+      +media-breakpoint-up(md)
+        height: 17px
+        top: unset
 
   &__go-to
     text-decoration: none

--- a/src/styles/components/headliners-container.sass
+++ b/src/styles/components/headliners-container.sass
@@ -12,8 +12,14 @@
     color: $color-grey-15
     margin-right: 7px
 
+    +media-breakpoint-up(md)
+      font-size: 30px
+
   &__results
     font-size: 15px
     font-weight: 300
     padding-bottom: 1px
     color: $color-grey-40
+
+    +media-breakpoint-up(md)
+      font-size: 18px

--- a/src/styles/components/headliners-placeholder.sass
+++ b/src/styles/components/headliners-placeholder.sass
@@ -8,18 +8,21 @@
   position: relative
   margin-bottom: 20px
 
-  // TODO: restyle later
-  //&:after
-  //  position: absolute
-  //  content: ''
-  //  width: 160px
-  //  left: -160px
-  //  border: 1px solid red
-  //  top: 0
-  //  bottom: 0
-  //  z-index: 1
-  //  background:  -webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,0.8) 50%,rgba(128,186,232,0) 99%,rgba(125,185,232,0) 100%)
-  //  animation: .7s linear infinite flow-right
+  +media-breakpoint-up(md)
+    display: flex
+    flex-direction: row-reverse
+    border: 1px solid $color-grey-75
+
+  &:after
+   position: absolute
+   content: ''
+   width: 100%
+   height: 800px
+   z-index: 1
+   top: -170px
+   transform: rotate(18deg)
+   background:  -webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,0.8) 50%,rgba(128,186,232,0) 99%,rgba(125,185,232,0) 100%)
+   animation: .8s linear infinite flow-right
 
   &__img
     width: 100%
@@ -27,11 +30,22 @@
     border-radius: 7px 7px 0 0
     background-color: $color-grey-75
 
+    +media-breakpoint-up(md)
+      width: 250px
+      height: 250px
+      border: 0 5px 5px 0
+      flex-shrink: 0
+      border-radius: 0 5px 5px 0
+
   &__content-wrapper
     padding: 13px 13px 15px
     border: 1px solid $color-grey-75
     border-top: none
     border-radius: 0 0 7px 7px
+
+    +media-breakpoint-up(md)
+      width: 100%
+      border: unset
 
   &__title
     width: 240px
@@ -40,12 +54,20 @@
     background-color: $color-grey-85
     margin-bottom: 5px
 
+    +media-breakpoint-up(md)
+      height: 28px
+      width: 95%
+      margin-bottom: 5px
+
   &__source
     width: 100px
     height: 12px
     border-radius: 3px
     background-color: $color-grey-85
     margin-bottom: 13px
+
+    +media-breakpoint-up(md)
+      height: 14px
 
   &__description
     width: 300px
@@ -54,8 +76,15 @@
     background-color: $color-grey-85
     margin-bottom: 5px
 
+    +media-breakpoint-up(md)
+      width: 90%
+      height: 17px
+
     &--shorter
       width: 100px
+
+      +media-breakpoint-up(md)
+        margin-bottom: 63px
 
   &__bottom
     display: flex
@@ -68,14 +97,22 @@
     background-color: $color-grey-85
     margin-right: 7px
 
+    +media-breakpoint-up(md)
+      width: 130px
+      height: 15px
+
   &__link
     width: 80px
     height: 13px
     border-radius: 3px
     background-color: $color-grey-85
 
+    +media-breakpoint-up(md)
+      width: 130px
+      height: 15px
+
 @keyframes flow-right
   0%
-    left: -160px
+    left: -100%
   100%
-    left: 400px
+    left: 100%

--- a/src/styles/components/search-container.sass
+++ b/src/styles/components/search-container.sass
@@ -9,9 +9,15 @@
     margin-bottom: 7px
     color: $color-grey-15
 
+    +media-breakpoint-up(md)
+      font-size: 30px
+
   &__description
     font-size: 15px
     font-weight: 300
     line-height: 20px
     margin-bottom: 15px
     color: $color-grey-25
+
+    +media-breakpoint-up(md)
+      font-size: 20px

--- a/src/styles/components/search-params.sass
+++ b/src/styles/components/search-params.sass
@@ -1,9 +1,26 @@
 .search-params
   margin-bottom: 30px
 
+  +media-breakpoint-up(md)
+    display: flex
+    flex-wrap: wrap
+    justify-content: space-between
+
   &__select-wrapper
     margin-bottom: 15px
+
+    +media-breakpoint-up(md)
+      width: 32%
 
     .params-select
       &__single-value
         overflow: unset
+
+      &__control
+        +media-breakpoint-up(md)
+          min-height: 43px
+
+      +media-breakpoint-up(md)
+        width: 100%
+        flex-shrink: 0
+        font-size: 18px

--- a/src/styles/components/search-sources.sass
+++ b/src/styles/components/search-sources.sass
@@ -1,2 +1,10 @@
 .search-sources
   margin-bottom: 15px
+
+  .sources-select
+    &__control
+      +media-breakpoint-up(md)
+        min-height: 43px
+
+    +media-breakpoint-up(md)
+      font-size: 18px


### PR DESCRIPTION
What was done:
- do styling for tablet level
- slightly change logic to show skeletons when reloading new headliners
- update useHeadlinersRequest to clear current headliners when making request for new ones